### PR TITLE
dep-update-cleanup Remove jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "eslint-plugin-modules-newline": "0.0.6",
     "eslint-plugin-unicorn": "43.0.2",
     "express": "4.18.1",
-    "jest": "28.1.3",
     "jest-html-reporters": "3.0.11",
     "ts-jest": "28.0.7",
     "typescript": "4.8.3"


### PR DESCRIPTION
Jest is already a dependency of ts-jest so it can be removed from package.json