### PR TITLE
118 Reduce output and usage of stacktrace in tests

### DIFF
--- a/tests/reassign.integration.test.ts
+++ b/tests/reassign.integration.test.ts
@@ -2,8 +2,7 @@
 import bodyParser from 'body-parser'
 import express from 'express'
 import {
-    GraphQLServer,
-    JsonLogger
+    GraphQLServer
 } from '~/src'
 
 import {
@@ -15,6 +14,7 @@ import {
 import {
     fetchResponse,
     GRAPHQL_SERVER_PORT,
+    NoStacktraceJsonLogger,
 } from './TestHelpers'
 import {PromiseOrValue} from 'graphql/jsutils/PromiseOrValue'
 import {ExecutionResult} from 'graphql'
@@ -29,7 +29,7 @@ test('Should reassign AggregateError to original errors field' +
     const customGraphQLServer = new GraphQLServer({
         schema: userSchema,
         rootValue: userSchemaResolvers,
-        logger: new JsonLogger('test-logger', 'reassign-service', true),
+        logger: new NoStacktraceJsonLogger('nostack-logger', 'reassign-service', true),
         reassignAggregateError: true,
         executeFunction: ():PromiseOrValue<ExecutionResult> => (multipleErrorResponse)
     })

--- a/tests/response/CustomResponseHandler.integration.test.ts
+++ b/tests/response/CustomResponseHandler.integration.test.ts
@@ -7,7 +7,6 @@ import {
     GraphQLServer,
     JsonLogger,
     ResponseParameters,
-    TextLogger
 } from '~/src'
 import {
     usersQuery,
@@ -19,6 +18,7 @@ import {
     fetchResponse,
     GRAPHQL_SERVER_PORT,
     INITIAL_GRAPHQL_SERVER_OPTIONS,
+    NoStacktraceTextLogger,
 } from '../TestHelpers'
 import {Buffer} from 'node:buffer'
 
@@ -61,7 +61,7 @@ test('Should return error if context serviceName is different as graphql server 
         customGraphQLServer.setOptions({
             schema: userSchema,
             rootValue: userSchemaResolvers,
-            logger: new TextLogger('test-logger', 'customGraphQLServer', true),
+            logger: new NoStacktraceTextLogger('test-logger', 'customGraphQLServer', true),
             reassignAggregateError: false,
             requestResponseContextFunction: (request, response, logger, serverOptions) => {
                 if (serverOptions && serverOptions.logger) {

--- a/tests/server/GraphQLServer.test.ts
+++ b/tests/server/GraphQLServer.test.ts
@@ -23,6 +23,7 @@ import {
     usersQuery,
     userTwo
 } from '../ExampleSchemas'
+import {TEXT_LOGGER} from '~/tests/TestHelpers'
 
 const graphQLErrorResponse: GraphQLExecutionResult = {
     executionResult: {
@@ -33,6 +34,7 @@ const graphQLErrorResponse: GraphQLExecutionResult = {
 
 test('Should create schema on GraphQLServer class creation', () => {
     const graphqlServer = new GraphQLServer({
+        logger: TEXT_LOGGER,
         schema: initialSchemaWithOnlyDescription,
         responseHandler: new DefaultResponseHandler(graphQLErrorResponse,
             graphQLErrorResponse,
@@ -46,7 +48,10 @@ test('Should create schema on GraphQLServer class creation', () => {
 })
 
 test('Should update schema when calling GraphQLServer updateGraphQLSchema function', () => {
-    const graphqlServer = new GraphQLServer({schema: initialSchemaWithOnlyDescription})
+    const graphqlServer = new GraphQLServer({
+        schema: initialSchemaWithOnlyDescription,
+        logger: TEXT_LOGGER
+    })
     const updatedSchema = new GraphQLSchema({description:'updated'})
     graphqlServer.setSchema(updatedSchema)
     const schema = graphqlServer.getSchema()
@@ -56,7 +61,10 @@ test('Should update schema when calling GraphQLServer updateGraphQLSchema functi
 })
 
 test('Should not update schema when given schema is undefined', () => {
-    const graphqlServer = new GraphQLServer({schema: initialSchemaWithOnlyDescription})
+    const graphqlServer = new GraphQLServer({
+        schema: initialSchemaWithOnlyDescription,
+        logger: TEXT_LOGGER
+    })
     graphqlServer.setSchema()
     const schema = graphqlServer.getSchema()
     expect(schema).toBeDefined()
@@ -67,6 +75,7 @@ test('Should not update schema when given schema is undefined', () => {
 test('Should update schema when given schema is undefined ' +
     'and shouldUpdateSchemaFunction is true', () => {
     const graphqlServer = new GraphQLServer({
+        logger: TEXT_LOGGER,
         schema: initialSchemaWithOnlyDescription
         , shouldUpdateSchemaFunction: (): boolean => true
     })
@@ -79,6 +88,7 @@ test('Should execute query without server', async() => {
     const graphqlServer = new GraphQLServer({
         schema: userSchema,
         rootValue: userSchemaResolvers,
+        logger: TEXT_LOGGER,
         requestInformationExtractor: new DefaultRequestInformationExtractor(),
         metricsClient: new DefaultMetricsClient(),
         collectErrorMetricsFunction: defaultCollectErrorMetrics,


### PR DESCRIPTION
#118 Create NoStack loggers for tests to greatly reduce log output in tests.