### PR TITLE
124 metrics init

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 name: Install and test graphql-server
-on: [push, pull_request]
+on: [push]
 
 jobs:
   graphqlserver:

--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ There are 3 builtin `MetricsClient` implementations available.
   metrics like cpu and memory usage.
 - **NoMetricsClient**: Does not collect any metrics. Can be used to disable metrics collection/increase performance.
 
+**Warning!**:
+If you are using **DefaultMetricsClient** you should avoid creating multiple **GraphQLServer** instances that all use the **DefaultMetricsClient**. Because of the usage of a global object in the [prom-client][3] library this might result in unexpected behaviour or malfunction. You can set another metrics client like **SimpleMetricsClient** by calling **GraphQLServer setOptions()** or **GraphQLServer setMetricsClient()**.   
+
 The **DefaultMetricsClient** and **SimpleMetricsClient** provide three custom metrics for the GraphQL server:
 
 - **graphql_server_availability**: Availability gauge with status 0 (unavailable) and 1 (available)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dreamit/graphql-server",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A GraphQL server written in NodeJS/Typescript.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/src/server/DefaultGraphQLServerOptions.ts
+++ b/src/server/DefaultGraphQLServerOptions.ts
@@ -1,6 +1,5 @@
 import {
     GraphQLServerOptions,
-    DefaultMetricsClient,
     DefaultRequestInformationExtractor,
     TextLogger,
     GraphQLServerRequest,
@@ -41,7 +40,13 @@ export class DefaultGraphQLServerOptions implements GraphQLServerOptions {
     logger: Logger = fallbackTextLogger
     requestInformationExtractor: RequestInformationExtractor = defaultRequestInformationExtractor
     responseHandler: ResponseHandler = defaultResponseHandler
-    metricsClient: MetricsClient = getDefaultMetricsClient()
+
+    /*
+     * Metrics client to be used as default client. Is initialised with SimpleMetricsClient
+     * here because initialising a MetricsClient that uses prom-client multiple times might result
+     * in unexpected and hard to control behaviour.
+     */
+    metricsClient: MetricsClient = new SimpleMetricsClient()
     formatErrorFunction = defaultFormatErrorFunction
     collectErrorMetricsFunction = defaultCollectErrorMetrics
     schemaValidationFunction = validateSchema
@@ -63,12 +68,6 @@ export class DefaultGraphQLServerOptions implements GraphQLServerOptions {
     fieldResolver?: Maybe<GraphQLFieldResolver<unknown, unknown>>
     typeResolver?: Maybe<GraphQLTypeResolver<unknown, unknown>>
     schema?: GraphQLSchema
-}
-
-export function getDefaultMetricsClient(): MetricsClient {
-    return 'cpuUsage' in process && typeof process.cpuUsage === 'function'
-        ? new DefaultMetricsClient()
-        : new SimpleMetricsClient()
 }
 
 /**

--- a/src/server/GraphQLServer.ts
+++ b/src/server/GraphQLServer.ts
@@ -56,13 +56,9 @@ export class GraphQLServer {
      * @param {MetricsClient} metricsClient - The metrics client to use in the GraphQLServer
      */
     setMetricsClient(metricsClient?: MetricsClient): void {
-        if (metricsClient) {
-            this.options.metricsClient = metricsClient
-        } else if ('cpuUsage' in process && typeof process.cpuUsage === 'function') {
-            this.options.metricsClient = new DefaultMetricsClient()
-        } else {
-            this.options.metricsClient = new SimpleMetricsClient()
-        }
+       const { cpuUsage } = process
+       this.options.metricsClient = metricsClient || (typeof cpuUsage === 'function') ?
+           new DefaultMetricsClient() : new SimpleMetricsClient()
         this.options.metricsClient.setAvailability(this.isValidSchema(this.options.schema) ? 1 : 0)
     }
 

--- a/src/server/GraphQLServer.ts
+++ b/src/server/GraphQLServer.ts
@@ -56,9 +56,9 @@ export class GraphQLServer {
      * @param {MetricsClient} metricsClient - The metrics client to use in the GraphQLServer
      */
     setMetricsClient(metricsClient?: MetricsClient): void {
-       const { cpuUsage } = process
-       this.options.metricsClient = metricsClient || (typeof cpuUsage === 'function') ?
-           new DefaultMetricsClient() : new SimpleMetricsClient()
+        const { cpuUsage } = process
+        this.options.metricsClient = metricsClient ?? ((typeof cpuUsage === 'function') ?
+            new DefaultMetricsClient() : new SimpleMetricsClient())
         this.options.metricsClient.setAvailability(this.isValidSchema(this.options.schema) ? 1 : 0)
     }
 

--- a/tests/metrics/MetricsClients.integration.test.ts
+++ b/tests/metrics/MetricsClients.integration.test.ts
@@ -371,7 +371,7 @@ async function testFetchErrorResponseMetrics(metricsClient: MetricsClient,
             `graphql_server_errors{errorClass="${SYNTAX_ERROR}"} 0`
         )
     }
-    // customGraphQLServer.setOptions(getInitialGraphQLServerOptions(metricsClient))
+    customGraphQLServer.setOptions(getInitialGraphQLServerOptions(metricsClient))
 }
 
 function setupGraphQLServer(): Express {

--- a/tests/metrics/MetricsClients.integration.test.ts
+++ b/tests/metrics/MetricsClients.integration.test.ts
@@ -36,7 +36,6 @@ import {
     NoSchemaIntrospectionCustomRule
 } from 'graphql'
 
-
 let customGraphQLServer: GraphQLServer
 let graphQLServer: Server
 let metricsResponseBody: string
@@ -52,19 +51,19 @@ afterAll(() => {
 
 test('Should get correct metrics for DefaultMetricsClient', async() => {
     const metricsClient =  new DefaultMetricsClient()
-    customGraphQLServer.setOptions(getInitialGraphQLServerOptions(metricsClient))
+    customGraphQLServer.setMetricsClient(metricsClient)
     await runMetricsTest(metricsClient, false)
 })
 
 test('Should get correct metrics for SimpleMetricsClient', async() => {
     const metricsClient = new SimpleMetricsClient()
-    customGraphQLServer.setOptions(getInitialGraphQLServerOptions(metricsClient))
+    customGraphQLServer.setMetricsClient(metricsClient)
     await runMetricsTest(metricsClient, false)
 })
 
 test('Should get no metrics for NoMetricsClient', async() => {
     const metricsClient = new NoMetricsClient()
-    customGraphQLServer.setOptions(getInitialGraphQLServerOptions(metricsClient))
+    customGraphQLServer.setMetricsClient(metricsClient)
     await runMetricsTest(metricsClient, true)
 })
 
@@ -372,6 +371,7 @@ async function testFetchErrorResponseMetrics(metricsClient: MetricsClient,
             `graphql_server_errors{errorClass="${SYNTAX_ERROR}"} 0`
         )
     }
+    // customGraphQLServer.setOptions(getInitialGraphQLServerOptions(metricsClient))
 }
 
 function setupGraphQLServer(): Express {

--- a/tests/server/GraphQLServer.test.ts
+++ b/tests/server/GraphQLServer.test.ts
@@ -173,6 +173,14 @@ test('Usage of a second GraphQLServer with MetricsClient that does not use prom-
     )
 })
 
+test('Should set only default options if no options are provided', async() => {
+    const graphqlServer = new GraphQLServer()
+    const metrics = await graphqlServer.getMetrics()
+    expect(metrics).toContain(
+        'graphql_server_availability 0'
+    )
+})
+
 function expectRootQueryNotDefined(graphqlServer: GraphQLServer): void {
     const schemaValidationErrors = graphqlServer.getSchemaValidationErrors()
     expect(schemaValidationErrors?.length).toBe(1)

--- a/tests/server/GraphQLServer.test.ts
+++ b/tests/server/GraphQLServer.test.ts
@@ -13,7 +13,7 @@ import {
     DefaultResponseHandler,
     GraphQLExecutionResult,
     GraphQLServer,
-    DefaultGraphQLServerOptions
+    SimpleMetricsClient
 } from '~/src'
 import {
     initialSchemaWithOnlyDescription,
@@ -110,13 +110,13 @@ test('Should use SimpleMetricsClient as fallback if cpuUsage is not available', 
 
     // eslint-disable-next-line no-global-assign
     process = {} as NodeJS.Process
+    // Necessary for Jest to measure/evaluate test performance
+    process.hrtime = savedProcess.hrtime
 
-    const defaultOptions = new DefaultGraphQLServerOptions()
-    const newOptions = {
+    const graphqlServer = new GraphQLServer({
         schema: userSchema,
         rootValue: userSchemaResolvers
-    }
-    const graphqlServer = new GraphQLServer({...defaultOptions, ...newOptions})
+    })
     const metrics = await graphqlServer.getMetrics()
     expect(metrics).toContain(
         'graphql_server_availability 1'
@@ -127,6 +127,50 @@ test('Should use SimpleMetricsClient as fallback if cpuUsage is not available', 
 
     // eslint-disable-next-line no-global-assign
     process = savedProcess
+})
+
+test('Usage of a second GraphQLServer with MetricsClient that does not use prom-client' +
+    ' should not intervene with metrics collection of first server', async() => {
+    console.info('Running new test')
+    const graphqlServerMain = new GraphQLServer({
+        schema: userSchema,
+        rootValue: userSchemaResolvers,
+        logger: TEXT_LOGGER,
+    })
+
+    // Execute request on main server twice to get throughput count of 2
+    await graphqlServerMain.executeRequest({
+        query: usersQuery
+    })
+    await graphqlServerMain.executeRequest({
+        query: usersQuery
+    })
+    let metrics = await graphqlServerMain.getMetrics()
+    expect(metrics).toContain(
+        'graphql_server_request_throughput 2'
+    )
+
+    const graphqlServerSecond = new GraphQLServer({
+        schema: userSchema,
+        rootValue: userSchemaResolvers,
+        logger: TEXT_LOGGER,
+        metricsClient: new SimpleMetricsClient()
+    })
+
+    // Execute request on second server once to get throughput count of 1
+    await graphqlServerSecond.executeRequest({
+        query: usersQuery
+    })
+    metrics = await graphqlServerSecond.getMetrics()
+    expect(metrics).toContain(
+        'graphql_server_request_throughput 1'
+    )
+
+    // Metrics on main server should still have throughput count of 2
+    metrics = await graphqlServerMain.getMetrics()
+    expect(metrics).toContain(
+        'graphql_server_request_throughput 2'
+    )
 })
 
 function expectRootQueryNotDefined(graphqlServer: GraphQLServer): void {

--- a/tests/server/GraphQLServer.test.ts
+++ b/tests/server/GraphQLServer.test.ts
@@ -131,7 +131,6 @@ test('Should use SimpleMetricsClient as fallback if cpuUsage is not available', 
 
 test('Usage of a second GraphQLServer with MetricsClient that does not use prom-client' +
     ' should not intervene with metrics collection of first server', async() => {
-    console.info('Running new test')
     const graphqlServerMain = new GraphQLServer({
         schema: userSchema,
         rootValue: userSchemaResolvers,


### PR DESCRIPTION
Fixes issues in #124 
Note:
In the next major release we should think about using a non prom-client MetricsClient as default. The usage of the global object in prom-client tends to create unexpected behaviour and is not a good choice for multiple GraphQLServer instances.
Closes #124 