### PR TITLE
157 Remove ResponseParameters interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   "peerDependencies": {
     "graphql": "^16.0.0",
     "@sgohlke/graphql-prom-metrics": "^1.0.2",
-    "@sgohlke/graphql-server-base": "1.0.0"
+    "@sgohlke/graphql-server-base": "^1.0.1"
   }
 }

--- a/src/response/ResponseHandler.ts
+++ b/src/response/ResponseHandler.ts
@@ -1,14 +1,7 @@
 import {
     GraphQLExecutionResult,
-    GraphQLServerRequest,
-    GraphQLServerResponse,
-    Logger
+    ResponseParameters
 } from '@sgohlke/graphql-server-base'
-import {
-    ExecutionResult,
-    GraphQLError,
-    GraphQLFormattedError
-} from 'graphql'
 
 /**
  * Interface for ResponseHandler.
@@ -22,15 +15,4 @@ export interface ResponseHandler {
 
     /** Sends a response */
     sendResponse(responseParameters: ResponseParameters): void
-}
-
-export interface ResponseParameters {
-    readonly response: GraphQLServerResponse,
-    readonly context: unknown,
-    readonly logger: Logger
-    readonly formatErrorFunction: (error: GraphQLError) => GraphQLFormattedError
-    readonly request?: GraphQLServerRequest,
-    readonly customHeaders?: Record<string, string>,
-    readonly executionResult?: ExecutionResult,
-    readonly statusCode?: number,
 }


### PR DESCRIPTION
Remove `ResponseParameters` interface, import it from "@sgohlke/graphql-server-base". As `ResponseParameters` is available since graphql-server-base v1.0.1 we need to adjust the minimum required version in peerDependencies in package.json.